### PR TITLE
Added a guard for LastFm Empty response on now playing songs

### DIFF
--- a/src/NowPlaying.php
+++ b/src/NowPlaying.php
@@ -33,6 +33,10 @@ class NowPlaying
             return false;
         };
 
+        if (!isset($lastFmResponse['recenttracks']['track'][0])) {
+            return false;
+        }
+
         $lastTrack = $lastFmResponse['recenttracks']['track'][0];
 
         if (!isset($lastTrack['@attr']['nowplaying'])) {

--- a/tests/NowPlayingTest.php
+++ b/tests/NowPlayingTest.php
@@ -70,6 +70,21 @@ class NowPlayingTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @test */
+    public function it_will_return_false_if_there_is_an_empty_response()
+    {
+        $userName = 'murze';
+
+        $this->nowPlaying->shouldReceive('makeRequest')
+            ->withArgs([$userName])
+            ->once()
+            ->andReturn($this->getLastFmResponseWithEmptyValues());
+
+        $result = $this->nowPlaying->getTrackInfo($userName);
+
+        $this->assertFalse($result);
+    }
+
+    /** @test */
     public function it_will_raise_an_exception_when_invalid_data_is_returned()
     {
         $this->setExpectedException(BadResponse::class);
@@ -106,6 +121,25 @@ class NowPlayingTest extends \PHPUnit_Framework_TestCase
                 ],
             ],
         ],
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    protected function getLastFmResponseWithEmptyValues()
+    {
+        return [
+            "recenttracks" => [
+                "track" => [],
+                "@attr" => [
+                    "user" => "murze",
+                    "page" => "1",
+                    "perPage" => "1",
+                    "totalPages" => "0",
+                    "total" => "0",
+                ],
+            ],
         ];
     }
 }


### PR DESCRIPTION
## Summary

When the browser scrobbler does not not find a song, which is the case a lot with mixcloud.com, it seems like lastfm is treating it as nothing is currently playing. There is an error in the `NowPlaying::class` there it tries to find an offset that does not exist.

### Screens

![screen shot 2017-08-10 at 12 26 57 pm](https://user-images.githubusercontent.com/4479918/29166971-e5f8810c-7dc8-11e7-8083-6b335748dd5e.png)
![screen shot 2017-08-10 at 12 27 14 pm](https://user-images.githubusercontent.com/4479918/29166970-e5f4c4ae-7dc8-11e7-8673-baa4145a7ff2.png)
![screen shot 2017-08-10 at 12 27 57 pm](https://user-images.githubusercontent.com/4479918/29166969-e5f4236e-7dc8-11e7-895e-c29f730e30f3.png)

### Changes

- Updated the `getTrackListInfo()` to return false if the recently playing track has an empty array like the screenshot
- Added a test to cover the empty response received from lastfm.

Please feel free to comment and change this PR as you wish, I added this for our team dashboard and the fix is working fine for us hopefully it will help someone else also.  Thanks for your great work in sharing your collective knowledge with the rest of us. You guys rock 🎉 

