### PR TITLE
Update to PHPUnit 4.8.36 and support Mockery 1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_script:
   - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-source
 
 script:
-  - phpunit --coverage-text --coverage-clover=coverage.clover
+  - vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
 
 after_script:
   - php vendor/bin/ocular code-coverage:upload --format=php-clover coverage.clover

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
         "php" : "^5.5|^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.*",
-        "mockery/mockery": "^0.9.4"
+        "phpunit/phpunit": "^4.8.36",
+        "mockery/mockery": ">=0.9.9"
     },
     "autoload": {
         "psr-4": {

--- a/tests/NowPlayingTest.php
+++ b/tests/NowPlayingTest.php
@@ -3,10 +3,11 @@
 namespace Spatie\NowPlaying\Test;
 
 use Mockery;
+use PHPUnit\Framework\TestCase;
 use Spatie\NowPlaying\Exceptions\BadResponse;
 use Spatie\NowPlaying\NowPlaying;
 
-class NowPlayingTest extends \PHPUnit_Framework_TestCase
+class NowPlayingTest extends TestCase
 {
     /** @var  Mockery\Mock|NowPlaying */
     protected $nowPlaying;


### PR DESCRIPTION
I've added support to [`Mockery 1.0`](https://github.com/mockery/mockery/releases/tag/1.0) and use `PHPUnit\Framework\TestCase` instead of `PHPUnit_Framework_TestCase` while extending the TestCase. This will help us to update to PHPUnit 6, that's [no longer supports snake case namespaces](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I didn't update to `PHPUnit 5` 'cause this package still supports `PHP 5.5`.

I've also updated `TravisCI` to use the `PHPUnit` installed version, not the global one.