### PR TITLE
Also fetch album and url

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ $nowPlaying = Spatie\NowPlaying\NowPlaying($apiKey);
 $nowPlaying->getTrackInfo($lastFmUserName);
 ```
 
-If the specified user is currently playing a track you'll get backy and array with keys `artist`, `trackName` and `artwork`. The `getTrackInfo`-function will return `false` when a user is not currently playing a track.
+If the specified user is currently playing a track you'll get backy and array with keys `artist`, `album`, `trackName`, `artwork` and `url`. The `getTrackInfo`-function will return `false` when a user is not currently playing a track.
 
 If something goes wrong an instance of `Spatie\NowPlaying\Exceptions\BadResponse` will be thrown.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ $nowPlaying = Spatie\NowPlaying\NowPlaying($apiKey);
 $nowPlaying->getTrackInfo($lastFmUserName);
 ```
 
-If the specified user is currently playing a track you'll get backy and array with keys `artist`, `album`, `trackName`, `artwork` and `url`. The `getTrackInfo`-function will return `false` when a user is not currently playing a track.
+If the specified user is currently playing a track you'll get backy and array with keys `artist`, `album`, `trackName`, `artwork` and `trackUrl`. The `getTrackInfo`-function will return `false` when a user is not currently playing a track.
 
 If something goes wrong an instance of `Spatie\NowPlaying\Exceptions\BadResponse` will be thrown.
 

--- a/src/NowPlaying.php
+++ b/src/NowPlaying.php
@@ -49,7 +49,9 @@ class NowPlaying
 
         return [
             'artist' => $lastTrack['artist']['#text'],
+            'album' => $lastTrack['album']['#text'],
             'trackName' => $lastTrack['name'],
+            'trackUrl'  => $lastTrack['url'],
             'artwork' => $this->getImage($lastTrack, 'extralarge'),
         ];
     }

--- a/src/NowPlaying.php
+++ b/src/NowPlaying.php
@@ -51,7 +51,7 @@ class NowPlaying
             'artist' => $lastTrack['artist']['#text'],
             'album' => $lastTrack['album']['#text'],
             'trackName' => $lastTrack['name'],
-            'trackUrl'  => $lastTrack['url'],
+            'url'  => $lastTrack['url'],
             'artwork' => $this->getImage($lastTrack, 'extralarge'),
         ];
     }

--- a/tests/NowPlayingTest.php
+++ b/tests/NowPlayingTest.php
@@ -129,7 +129,7 @@ class NowPlayingTest extends TestCase
                     'image' => [
                         ['size' => 'extralarge', '#text' => $artwork],
                     ],
-                    'url' => $lastTrack['url'],
+                    'url' => $url,
                     '@attr' => ['nowplaying' => $nowPlaying],
                 ],
             ],

--- a/tests/NowPlayingTest.php
+++ b/tests/NowPlayingTest.php
@@ -33,20 +33,24 @@ class NowPlayingTest extends TestCase
     {
         $artist = 'Can';
 
+        $album = 'Kitchen';
+
         $trackName = 'Spoon';
 
         $artwork = 'https://last.fm/an-image.jpg';
+
+        $url = 'https://last.fm/a-song';
 
         $userName = 'murze';
 
         $this->nowPlaying->shouldReceive('makeRequest')
             ->withArgs([$userName])
             ->once()
-            ->andReturn($this->getLastFmResponse($artist, $trackName, $artwork));
+            ->andReturn($this->getLastFmResponse($artist, $album, $trackName, $artwork, $url));
 
         $result = $this->nowPlaying->getTrackInfo($userName);
 
-        $this->assertEquals(compact('artist', 'trackName', 'artwork'), $result);
+        $this->assertEquals(compact('artist', 'album', 'trackName', 'artwork', 'url'), $result);
     }
 
     /** @test */
@@ -54,16 +58,20 @@ class NowPlayingTest extends TestCase
     {
         $artist = 'Can';
 
+        $album = 'Kitchen';
+
         $trackName = 'Spoon';
 
         $artwork = 'https://last.fm/an-image.jpg';
+
+        $url = 'https://last.fm/a-song';
 
         $userName = 'murze';
 
         $this->nowPlaying->shouldReceive('makeRequest')
             ->withArgs([$userName])
             ->once()
-            ->andReturn($this->getLastFmResponse($artist, $trackName, $artwork, false));
+            ->andReturn($this->getLastFmResponse($artist, $album, $trackName, $artwork, $url, false));
 
         $result = $this->nowPlaying->getTrackInfo($userName);
 
@@ -102,22 +110,26 @@ class NowPlayingTest extends TestCase
 
     /**
      * @param $artist
+     * @param $album
      * @param $trackName
      * @param $artwork
+     * @param $url
      * @param bool $nowPlaying
      *
      * @return array
      */
-    protected function getLastFmResponse($artist, $trackName, $artwork, $nowPlaying = true)
+    protected function getLastFmResponse($artist, $album, $trackName, $artwork, $url, $nowPlaying = true)
     {
         return ['recenttracks' => [
             'track' => [
                 [
                     'artist' => ['#text' => $artist],
+                    'album' => ['#text' => $album],
                     'name' => $trackName,
                     'image' => [
                         ['size' => 'extralarge', '#text' => $artwork],
                     ],
+                    'url' => $lastTrack['url'],
                     '@attr' => ['nowplaying' => $nowPlaying],
                 ],
             ],


### PR DESCRIPTION
When customizing your dashboard, I saw you're checking for a `url` parameter, but it's never retrieved by the package. I also added an album field I'm used on my version :octocat: 	